### PR TITLE
Fix example of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,18 @@ __Example of usage (Don't forget include the rest of necessary .js libs such as 
       <head>
         <script type="text/javascript" charset="utf-8" src="cordova-X.X.X.js"></script>
         <script type="text/javascript" charset="utf-8" src="jquery.js"></script>
-        <script type="text/javascript" charset="utf-8" src="VolumeControl.js"></script>
         <script type="text/javascript" charset="utf-8">
           //Set volume to 95 when click button
           $('#volUp').bind('click',function(){
-             VolumeControl.setVolume(95, onVolSuccess, onVolError);
+             cordova.plugins.VolumeControl.setVolume(95, onVolSuccess, onVolError);
           });
           //Set volume to 25 when click button
           $('#volDown').bind('click',function(){
-              VolumeControl.setVolume(25, onVolSuccess, onVolError);
+              cordova.plugins.VolumeControl.setVolume(25, onVolSuccess, onVolError);
           });
           //Get current volume
           $('#currVol').bind('click',function(){
-              VolumeControl.getVolume(getVolSuccess, getVolError);
+              cordova.plugins.VolumeControl.getVolume(getVolSuccess, getVolError);
           });
           //Callbacks
           function onVolSuccess(){

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage the music volume to your app.  Create a slider bar or control buttons.  C
 Installation:
 -------------
 1. Install using Cordova CLI:
-    `cordova plugin add git+https://github.com/manusimpson/Phonegap-Android-VolumeControl.git`
+    `cordova plugin add https://github.com/manusimpson/Phonegap-Android-VolumeControl.git`
 
 __Example of usage (Don't forget include the rest of necessary .js libs such as cordova,jquery and css, etc):__
 


### PR DESCRIPTION
There were some minor errors in the example of usage.

The URL used to add the plugin was wrong. The correct protocol is https, not git+https

```
cordova plugin add https://github.com/manusimpson/Phonegap-Android-VolumeControl.git
```

There is a js-module tag for VolumeControl.js in the plugin.xml file, so there is no need to add the VolumeControl.js script.

```
<script type="text/javascript" charset="utf-8" src="VolumeControl.js"></script>
```

The target property defined in the plugin.xml file is cordova.plugins.VolumeControl, so VolumeControl must be called as cordova.plugins.VolumeControl, for example:

```
cordova.plugins.VolumeControl.getVolume(getVolSuccess, getVolError);
```
